### PR TITLE
rofl-8004: Fetch on-chain ROFL metadata, store agent_id to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ your ROFL `compose.yaml`:
       - PINATA_JWT=${PINATA_JWT}
     volumes:
       - /run/rofl-appd.sock:/run/rofl-appd.sock
+      - rofl-8004-volume:/root/.rofl-8004
+
+volumes:
+  rofl-8004-volume:
 ```
 
 Oasis gas fees are covered by the ROFL node hosting your application. Ethereum

--- a/example/compose.yaml
+++ b/example/compose.yaml
@@ -36,6 +36,7 @@ services:
       #- VALIDATOR_ADDRESS=0x7cd2eccd146b6626c8a500ab5644b1a506115e6f
     volumes:
       - /run/rofl-appd.sock:/run/rofl-appd.sock
+      - rofl-8004-volume:/root/.rofl-8004
 
   my-app:
     image: docker.io/hashicorp/http-echo:latest@sha256:fcb75f691c8b0414d670ae570240cbf95502cc18a9ba57e982ecac589760a186
@@ -44,3 +45,6 @@ services:
       ECHO_TEXT: "hello ROFL+ERC-8004 world"
     ports:
       - "5678:5678"
+
+volumes:
+  rofl-8004-volume:

--- a/example/rofl.yaml
+++ b/example/rofl.yaml
@@ -37,8 +37,8 @@ deployments:
           min_tcb_evaluation_data_number: 18
           tdx: {}
       enclaves:
-        - id: GLF9Cl2NOfQbcSVXCxramPPNkF9sLNA+aQ6Hd6kB9HsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-        - id: R0Ckayp3A1X0TYl+VTbox4KL3E/TYh4khb1zNY/cQxkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+        - id: y2XRFrPuM/jxdMuJftyNptQfVpaWRxTfAlKWbHAMslcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+        - id: kSFc9NKgxsu5xlpEYvG3RoeF/4GLwz3docQXSBnc4ScAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
       endorsements:
         - any: {}
       fees: endorsing_node
@@ -54,6 +54,6 @@ deployments:
       default:
         provider: oasis1qp2ens0hsp7gh23wajxa4hpetkdek3swyyulyrmz
         offer: playground_short
-        id: 00000000000004fe
+        id: "0000000000000501"
 tooling:
   version: 0.18.1-gitf730dfe

--- a/example/rofl.yaml
+++ b/example/rofl.yaml
@@ -3,6 +3,7 @@ version: 0.1.0
 repository: https://github.com/oasisprotocol/erc-8004
 author: Matevž Jekovec <matevz@oasisprotocol.org>
 license: Apache-2.0
+description: Example ROFL for ERC-8004 integration.
 tee: tdx
 kind: container
 resources:
@@ -12,11 +13,12 @@ resources:
     kind: disk-persistent
     size: 5000
 artifacts:
+  builder: ghcr.io/oasisprotocol/rofl-container-builder:0.0.1@sha256:913ef97ab07dde31f08ce873f825bf3d4f32ad4102ff5797d7c3050c121c4dce
   firmware: https://github.com/oasisprotocol/oasis-boot/releases/download/v0.6.2/ovmf.tdx.fd#db47100a7d6a0c1f6983be224137c3f8d7cb09b63bb1c7a5ee7829d8e994a42f
   kernel: https://github.com/oasisprotocol/oasis-boot/releases/download/v0.6.2/stage1.bin#e5d4d654ca1fa2c388bf64b23fc6e67815893fc7cb8b7cfee253d87963f54973
   stage2: https://github.com/oasisprotocol/oasis-boot/releases/download/v0.6.2/stage2-podman.tar.bz2#b2ea2a0ca769b6b2d64e3f0c577ee9c08f0bb81a6e33ed5b15b2a7e50ef9a09f
   container:
-    runtime: https://github.com/oasisprotocol/oasis-sdk/releases/download/rofl-containers%2Fv0.8.4/rofl-containers#2cd0468ec2ea5f4264f47f728c5c3b0fcce93f5a537e568f8cbab8a53b526ae7
+    runtime: https://github.com/oasisprotocol/oasis-sdk/releases/download/rofl-containers%2Fv0.8.6/rofl-containers#5aa26a3c5a7e1d284e217959d89b7a620ea7b7fc5079909e25042124ffb384e8
     compose: compose.yaml
 deployments:
   default:
@@ -35,8 +37,8 @@ deployments:
           min_tcb_evaluation_data_number: 18
           tdx: {}
       enclaves:
-        - id: 9myRGQwT21YbdqpZ0Vkom5C6imhg31ij0Wtk0qzHWboAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
-        - id: 29TZUhAMrwctsgOrPK2UOKYFA6eI/e4/wTNlyefZPWIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+        - id: GLF9Cl2NOfQbcSVXCxramPPNkF9sLNA+aQ6Hd6kB9HsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+        - id: R0Ckayp3A1X0TYl+VTbox4KL3E/TYh4khb1zNY/cQxkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
       endorsements:
         - any: {}
       fees: endorsing_node
@@ -52,3 +54,6 @@ deployments:
       default:
         provider: oasis1qp2ens0hsp7gh23wajxa4hpetkdek3swyyulyrmz
         offer: playground_short
+        id: 00000000000004fe
+tooling:
+  version: 0.18.1-gitf730dfe

--- a/rofl-8004/Dockerfile
+++ b/rofl-8004/Dockerfile
@@ -1,9 +1,9 @@
 FROM docker.io/python:3-slim
-WORKDIR /rofl-8004
 
 COPY . /rofl-8004
 
 RUN apt update && apt install -y git python3-dev gcc libc-dev && apt clean && rm -rf /var/lib/apt/lists/*
-RUN pip install -r requirements.txt
+RUN cd /rofl-8004 && pip install -r requirements.txt
 
-CMD ["python", "main.py"]
+WORKDIR /root
+CMD ["python", "/rofl-8004/main.py"]

--- a/rofl-8004/main.py
+++ b/rofl-8004/main.py
@@ -22,7 +22,7 @@ def main():
         sys.exit("PINATA_JWT is required")
 
     metadata_handler = RoflMetadata()
-    metadata = metadata_handler.client.get_metadata()
+    replica_metadata = metadata_handler.client.get_metadata()
 
     private_key_id = os.getenv("ERC8004_SIGNING_KEY_ID", ERC8004_SIGNING_KEY_ID)
     private_key = os.getenv("ERC8004_SIGNING_KEY") or None
@@ -47,12 +47,13 @@ def main():
     # Send ValidationRequest to ERC-8004 registry.
     agent_id = os.getenv("AGENT_ID") or None
     if agent_id is None:
-        agent_id = metadata.get(ERC8004_AGENT_ID_KEY, None)
+        agent_id = replica_metadata.get(ERC8004_AGENT_ID_KEY, None)
     if agent_id is None:
-        name = os.getenv("AGENT_NAME") or "rofl-agent"
-        description = os.getenv("AGENT_DESCRIPTION") or "Oasis ROFL-powered trustless agent."
+        app_metadata = metadata_handler.get_app_metadata()
+        name = os.getenv("AGENT_NAME") or app_metadata["name"] or "rofl-agent"
+        description = os.getenv("AGENT_DESCRIPTION") or app_metadata["description"] or "Oasis ROFL-powered trustless agent."
         image = os.getenv("AGENT_IMAGE") or None
-        version = os.getenv("AGENT_VERSION") or "0.1.0"
+        version = os.getenv("AGENT_VERSION") or app_metadata["version"] or "0.1.0"
         category = os.getenv("AGENT_CATEGORY") or "rofl"
         mcp = os.getenv("AGENT_MCP") or None
         a2a = os.getenv("AGENT_A2A") or None
@@ -61,16 +62,16 @@ def main():
         agent_id = erc8004.register_agent(app_id, name, description, image, version, category, mcp, a2a, ens)
 
     # Store agent ID to ROFL metadata.
-    metadata[ERC8004_AGENT_ID_KEY] = agent_id
+    replica_metadata[ERC8004_AGENT_ID_KEY] = agent_id
 
     # Store the public key of the ERC-8004 signing key (either provided or TEE-derived) to ROFL metadata.
-    metadata[f"{private_key_id}.pk"] = RoflMetadata.derive_pubkey(bytes.fromhex(private_key), KeyKind.SECP256K1).hex()
+    replica_metadata[f"{private_key_id}.pk"] = RoflMetadata.derive_pubkey(bytes.fromhex(private_key), KeyKind.SECP256K1).hex()
 
     # Update ROFL replica metadata with exposed public keys.
     key_ids = os.getenv("PUBLIC_KEY_IDS")
 
     # Store any new keys or agent ID.
-    metadata_handler.store_public_keys(key_ids.split(",") if key_ids else [], metadata)
+    metadata_handler.store_public_keys(key_ids.split(",") if key_ids else [], replica_metadata)
 
     erc8004.validation_request(agent_id, os.getenv("VALIDATOR_ADDRESS", "0x7b60d730B6FBb55F9e4D1DB33B2D476e9c19fd35"))
 

--- a/rofl-8004/main.py
+++ b/rofl-8004/main.py
@@ -1,3 +1,4 @@
+import json
 import os
 import time
 import sys
@@ -7,6 +8,8 @@ from eth_account import Account
 import logging
 from rofl_metadata import RoflMetadata, ERC8004_SIGNING_KEY_ID, ERC8004_AGENT_ID_KEY
 from oasis_rofl_client import KeyKind
+
+ROFL_8004_CONFIG_FILENAME = ".rofl-8004/rofl-8004.json"
 
 def main():
     logging.basicConfig(
@@ -44,10 +47,18 @@ def main():
         logging.info(f"Account {address} has no balance. Please top it up in order to register a new ERC-8004 agent and submit the validation request.")
         time.sleep(5)
 
-    # Send ValidationRequest to ERC-8004 registry.
+    # Check for ROFL config on persistent storage.
+    rofl_config = {}
+    if os.path.exists(ROFL_8004_CONFIG_FILENAME):
+        with open(ROFL_8004_CONFIG_FILENAME, "r") as f:
+            rofl_config = json.load(f)
+            logging.info(f"Loaded ROFL config file from {ROFL_8004_CONFIG_FILENAME}")
+
     agent_id = os.getenv("AGENT_ID") or None
     if agent_id is None:
-        agent_id = replica_metadata.get(ERC8004_AGENT_ID_KEY, None)
+        agent_id = rofl_config.get("agent_id")
+    if agent_id is None:
+        agent_id = replica_metadata.get(ERC8004_AGENT_ID_KEY)
     if agent_id is None:
         app_metadata = metadata_handler.get_app_metadata()
         name = os.getenv("AGENT_NAME") or app_metadata["name"] or "rofl-agent"
@@ -61,6 +72,13 @@ def main():
         app_id = metadata_handler.client.get_app_id()
         agent_id = erc8004.register_agent(app_id, name, description, image, version, category, mcp, a2a, ens)
 
+    # Store agent ID to disk.
+    rofl_config["agent_id"] = agent_id
+    os.makedirs(os.path.dirname(ROFL_8004_CONFIG_FILENAME), exist_ok=True)
+    with open(ROFL_8004_CONFIG_FILENAME, "w") as f:
+        json.dump(rofl_config, f)
+        logging.info(f"Stored ROFL config file to {ROFL_8004_CONFIG_FILENAME}")
+
     # Store agent ID to ROFL metadata.
     replica_metadata[ERC8004_AGENT_ID_KEY] = agent_id
 
@@ -73,6 +91,7 @@ def main():
     # Store any new keys or agent ID.
     metadata_handler.store_public_keys(key_ids.split(",") if key_ids else [], replica_metadata)
 
+    # Send ValidationRequest to ERC-8004 registry.
     erc8004.validation_request(agent_id, os.getenv("VALIDATOR_ADDRESS", "0x7b60d730B6FBb55F9e4D1DB33B2D476e9c19fd35"))
 
 if __name__ == "__main__":

--- a/rofl-8004/requirements.txt
+++ b/rofl-8004/requirements.txt
@@ -1,4 +1,6 @@
 agent0-sdk
+bech32
+cbor2
 ecdsa
 #oasis-rofl-client
 git+https://github.com/oasisprotocol/oasis-sdk.git@matevz/feature/rofl-client-py-sync#egg=oasis-rofl-client&subdirectory=rofl-client/py

--- a/rofl-8004/rofl_metadata.py
+++ b/rofl-8004/rofl_metadata.py
@@ -1,3 +1,5 @@
+import bech32
+import cbor2
 import logging
 from ecdsa import SigningKey, SECP256k1, Ed25519
 from oasis_rofl_client import RoflClient, KeyKind
@@ -34,6 +36,26 @@ class RoflMetadata:
             self.client.set_metadata(metadata)
 
         return metadata
+
+    def get_app_metadata(self) -> dict[str, str]:
+        """Returns app metadata stored on-chain"""
+
+        app_id = self.client.get_app_id()
+        _, bech32_data = bech32.bech32_decode(app_id)
+        app_id_bytes = bytes(bech32.convertbits(bech32_data, 5, 8, False))
+
+        response = self.client.query("rofl.App", cbor2.dumps({"id": app_id_bytes}))
+        app_metadata = cbor2.loads(response)["metadata"]
+
+        return {
+            "name": app_metadata.get("net.oasis.rofl.name"),
+            "version": app_metadata.get("net.oasis.rofl.version"),
+            "repository": app_metadata.get("net.oasis.rofl.repository"),
+            "author": app_metadata.get("net.oasis.rofl.author"),
+            "license": app_metadata.get("net.oasis.rofl.license"),
+            "homepage": app_metadata.get("net.oasis.rofl.homepage"),
+            "description": app_metadata.get("net.oasis.rofl.description"),
+        }
 
     def derive_pubkey(key: bytes, kind: KeyKind) -> bytes:
         match kind:


### PR DESCRIPTION
This PR implements #8 and #10. Also updates rofl.yaml of the example to the latest Oasis CLI builders.